### PR TITLE
Gemfile: Uninstall Solargraph

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :development do
   gem 'pry-rails'
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
-  gem 'solargraph'
   gem 'spring'
   gem 'spring-commands-rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,9 +63,7 @@ GEM
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    backport (1.2.0)
     bcrypt (3.1.20)
-    benchmark (0.2.0)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -84,7 +82,6 @@ GEM
     crass (1.0.6)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    e2mmap (0.1.0)
     erubi (1.12.0)
     execjs (2.8.1)
     factory_bot (6.4.3)
@@ -118,7 +115,6 @@ GEM
       activesupport (>= 5.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.4)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -127,10 +123,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.6.2)
-    kramdown (2.4.0)
-      rexml
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
     launchy (2.5.2)
       addressable (~> 2.8)
     less (2.6.0)
@@ -215,8 +207,6 @@ GEM
       ffi (~> 1.0)
     rdoc (6.3.3)
     regexp_parser (2.8.3)
-    reverse_markdown (2.1.1)
-      nokogiri
     rexml (3.2.6)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
@@ -281,21 +271,6 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.3)
-    solargraph (0.45.0)
-      backport (~> 1.2)
-      benchmark
-      bundler (>= 1.17.2)
-      diff-lcs (~> 1.4)
-      e2mmap
-      jaro_winkler (~> 1.5)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.1)
-      parser (~> 3.0)
-      reverse_markdown (>= 1.0.5, < 3)
-      rubocop (>= 0.52)
-      thor (~> 1.0)
-      tilt (~> 2.0)
-      yard (~> 0.9, >= 0.9.24)
     spring (4.0.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -323,15 +298,12 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.2.0)
-    webrick (1.7.0)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.12)
     zipkin-tracer (0.47.3)
       faraday (>= 0.13, < 2.0)
@@ -366,7 +338,6 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
   simplecov-lcov (~> 0.8.0)
-  solargraph
   spring
   spring-commands-rspec
   turbolinks


### PR DESCRIPTION
In favor of [ruby-lsp](https://github.com/Shopify/ruby-lsp)