### PR TITLE
deps: Update Bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,4 +421,4 @@ DEPENDENCIES
   zipkin-tracer
 
 BUNDLED WITH
-   2.2.33
+   2.6.7


### PR DESCRIPTION
To suppress the following error:

> Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.